### PR TITLE
Check that the job.ID field is not empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,10 @@ func NewJob(data []byte) (j Job, err error) {
 		err = errors.New("Missing ID")
 		return
 	}
+	if j["id"] == "" {
+		err = errors.New("ID is empty")
+		return
+	}
 	switch j["id"].(type) {
 	case string:
 		return


### PR DESCRIPTION
Previously checked that the job.ID map key existed, but not if it was empty. Marathon-client panics and exists if the value is empty. 